### PR TITLE
Resolves #43

### DIFF
--- a/src/Campers.js
+++ b/src/Campers.js
@@ -5,10 +5,10 @@ class Campers extends Component {
   constructor(props){
     super(props);
     var date = new Date(this.props.camper.endTime).toTimeString();
-    var setup = Array.from(this.props.camper.setup);
-    setup.splice(setup.length-1, 1); //to remove the extra comma
+    var setup = this.props.camper.setup;
+
     this.state = { end: (date.substr(0,5) + ' ' + date.substr(9, date.length)), 
-                   techSetup: setup.join(", ")};
+                   techSetup: Array.isArray(setup) ? setup.join(', ') : setup};
   }
   
   render() {


### PR DESCRIPTION
So, I'm not really sure what the logic in converting to an array and then joining was before. Thing is, `this.props.camper.setup` contains a string in the case of a single value, and is already an array in the case of multiple values. My changes should be obvious given that information. If you need more of an explanation, feel free to ask.