### PR TITLE
Hash navigation

### DIFF
--- a/FIRST_PR_CLUB.md
+++ b/FIRST_PR_CLUB.md
@@ -15,4 +15,8 @@ Oh, and: First!!!!!
 
 * my third try :) sorry.
 
+---
 
+* [MarcoThePoro](https://github.com/MarcoThePoro) :) Did all the exercises in front-end but can't get myself to stick to the projects. I'm from Melbourne. I've made a few PRs to a little atom plugin called less-than-slash. I want to add simple hash routing so the url reflects which modals are open.
+
+---

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "react-scripts": "0.7.0"
   },
   "dependencies": {
+    "history": "^4.4.1",
     "react": "^15.4.0",
     "react-bootstrap": "^0.30.7",
     "react-dom": "^15.4.0"

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Button, Glyphicon, Modal } from 'react-bootstrap';
 
 import './App.css';
 import Campers from './Campers';
+import { withHash } from './History';
 
 class App extends Component {
 
@@ -10,20 +11,18 @@ class App extends Component {
     super();
     this.state = {
       campers: [],
-      showModal: false,
-      showInfo: false
     };
 
     this.close = () => {
-      this.setState({ showModal: false, showInfo: false});
+      this.props.replaceHash('');
     };
 
     this.open = () => {
-      this.setState({ showModal: true });
+      this.props.replaceHash('#add');
     };
 
     this.openInfo = () => {
-      this.setState({ showInfo: true });
+      this.props.replaceHash('#info');
     }
 }
 
@@ -36,6 +35,8 @@ class App extends Component {
   }
 
   render() {
+    let showModal = this.props.hash === '#add';
+    let showInfo = this.props.hash === '#info';
     return (
       <div className="App">
         <div className="App-header">
@@ -47,7 +48,7 @@ class App extends Component {
               {this.state.campers.map((camper, i) => <div key={i} className='col-xs-12 col-md-6'><Campers camper={camper} key={i} /></div>)}
             </div>
           </div>
-          <Modal show={this.state.showModal} onHide={this.close}>
+          <Modal show={showModal} onHide={this.close}>
             <Modal.Header closeButton>
               <Modal.Title>Add your details to the board</Modal.Title>
             </Modal.Header>
@@ -75,7 +76,7 @@ class App extends Component {
               </form>
             </Modal.Body>
           </Modal>
-          <Modal show={this.state.showInfo} onHide={this.close}>
+          <Modal show={showInfo} onHide={this.close}>
             <Modal.Header closeButton>
               <Modal.Title>About</Modal.Title>
             </Modal.Header>
@@ -108,5 +109,9 @@ class App extends Component {
     );
   }
 }
+App.propTypes = {
+  hash: React.PropTypes.string.isRequired,
+  replaceHash: React.PropTypes.func.isRequired,
+}
 
-export default App;
+export default withHash(App);

--- a/src/History.js
+++ b/src/History.js
@@ -24,10 +24,17 @@ export function withHash(WrappedComponent) {
         this.history.replace({
           hash: newHash
         });
-        this.setState({
-          hash: newHash
-        });
       }
+    }
+    componentWillMount() {
+      this.unlisten = this.history.listen((location, action) => {
+        this.setState({
+          hash: location.hash,
+        });
+      });
+    }
+    componentWillUnmount() {
+      this.unlisten();
     }
     render() {
       return (

--- a/src/History.js
+++ b/src/History.js
@@ -27,7 +27,7 @@ export function withHash(WrappedComponent) {
       this.history = context.history;
 
       if (!this.history) {
-        throw new Error(`Could not find "history" is the context of ${displayName}. Wrap the root component in a <HistoryProvider`);
+        throw new Error(`Could not find "history" in the context of ${displayName}. Please wrap the root component in a <HistoryProvider>`);
       }
 
       this.state = {

--- a/src/History.js
+++ b/src/History.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import createBrowserHistory from 'history/createBrowserHistory';
+
+let history = createBrowserHistory();
+
+export default class HistoryProvider extends React.Component {
+  render() {
+    return this.props.children;
+  }
+  getChildContext() {
+    return { history };
+  }
+}
+HistoryProvider.childContextTypes = {
+  history: React.PropTypes.any,
+}
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
+export function withHash(WrappedComponent) {
+  const displayName = `WithHash(${getDisplayName(WrappedComponent)})`;
+  class WithHash extends React.Component {
+    constructor(props, context) {
+      super(props, context);
+      this.history = context.history;
+
+      if (!this.history) {
+        throw new Error(`Could not find "history" is the context of ${displayName}. Wrap the root component in a <HistoryProvider`);
+      }
+
+      this.state = {
+        hash: history.location.hash,
+      };
+      this.replaceHash = (newHash) => {
+        if (typeof newHash !== 'string' || (newHash.length > 0 && newHash[0] !== '#')) {
+          throw new Error(`Expected hash to be an empty string or a string starting with "#" but got ${newHash}`);
+        }
+        this.history.replace({
+          hash: newHash
+        });
+        this.setState({
+          hash: newHash
+        });
+      }
+    }
+    render() {
+      return (
+        <WrappedComponent {...this.props} hash={this.state.hash} replaceHash={this.replaceHash} />
+      )
+    }
+  }
+  WithHash.displayName = displayName;
+  WithHash.WrappedComponent = WrappedComponent;
+  WithHash.contextTypes = {
+    history: React.PropTypes.any,
+  };
+  return WithHash;
+}

--- a/src/History.js
+++ b/src/History.js
@@ -1,19 +1,7 @@
 import React from 'react';
 import createBrowserHistory from 'history/createBrowserHistory';
 
-let history = createBrowserHistory();
-
-export default class HistoryProvider extends React.Component {
-  render() {
-    return this.props.children;
-  }
-  getChildContext() {
-    return { history };
-  }
-}
-HistoryProvider.childContextTypes = {
-  history: React.PropTypes.any,
-}
+export const history = createBrowserHistory();
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'
@@ -24,14 +12,10 @@ export function withHash(WrappedComponent) {
   class WithHash extends React.Component {
     constructor(props, context) {
       super(props, context);
-      this.history = context.history;
-
-      if (!this.history) {
-        throw new Error(`Could not find "history" in the context of ${displayName}. Please wrap the root component in a <HistoryProvider>`);
-      }
+      this.history = history;
 
       this.state = {
-        hash: history.location.hash,
+        hash: this.history.location.hash,
       };
       this.replaceHash = (newHash) => {
         if (typeof newHash !== 'string' || (newHash.length > 0 && newHash[0] !== '#')) {
@@ -53,8 +37,5 @@ export function withHash(WrappedComponent) {
   }
   WithHash.displayName = displayName;
   WithHash.WrappedComponent = WrappedComponent;
-  WithHash.contextTypes = {
-    history: React.PropTypes.any,
-  };
   return WithHash;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
+import HistoryProvider from './History';
 
 ReactDOM.render(
-  <App />,
+  <HistoryProvider>
+    <App />
+  </HistoryProvider>,
   document.getElementById('root')
 );

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
-import HistoryProvider from './History';
 
 ReactDOM.render(
-  <HistoryProvider>
-    <App />
-  </HistoryProvider>,
+  <App />,
   document.getElementById('root')
 );


### PR DESCRIPTION
Hi,

I've read around the internet that having modals without reflecting their state in the url is **EVIL** D: so I decided to add some basic hash navigation. My first instinct was to reach for react-router but then I decided that would probably be **premature package-ization** considering there's only really one page in this app (or three if you count info, and add a listing as separate). So I just wrote it myself with the help of the [history](https://github.com/mjackson/history) module which makes it dead easy to make changes to the url.

Changes:
The `withHash` function decorates a component, (in this case `App`) providing it with two props: `hash` - the current hash (the portion of the url starting with `#`), and `replaceHash` which, you guessed it, replaces the current hash. I used a decorator because:
- it's cool
- it keeps all code that deals with the history object isolated and in one place

The App component no longer has `showModal` or `showInfo` in its state, instead it checks the current hash to see if it matches `#add` (for adding a new entry) or `#info` and uses that to decide which modals are visible. Instead of making calls to setState, the modals are opened and closed by calling `replaceHash` with `''` (for none open), `'#add'`, or `#info`.

@JacksonBates could you review?