### PR TITLE
Add validations and limit text field length

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -113,11 +113,11 @@ class App extends Component {
                 <label htmlFor='username'>Forum username:</label>
                 <div className='input-group'>
                   <span className="input-group-addon" id="basic-addon1">@</span>
-                  <input className='form-control' name='username' id='username' type='text' aria-describedby="basic-addon1" value={this.state.username} onChange={this.handleChange}/>
+                  <input pattern=".{1,20}" required title="Username between 1 and 20 characters" className='form-control' name='username' id='username' type='text' aria-describedby="basic-addon1" value={this.state.username} onChange={this.handleChange}/>
                 </div>
                 <label htmlFor='availableTime'>Length of Time Available for Pairing (example: 03:00 = 3hrs):</label>
                 <div className='input-group'>
-                  <input className='form-control' name='availableTime' id='availableTime' type='text' pattern='\d{1,2}:\d{2}' aria-describedby="basic-addon2" value={this.state.availableTime} onChange={this.handleChange}/>
+                  <input required title="Please enter in the format HH:mm" className='form-control' name='availableTime' id='availableTime' type='text' pattern='\d{1,2}:\d{2}' aria-describedby="basic-addon2" value={this.state.availableTime} onChange={this.handleChange}/>
                   <span className="input-group-addon" id="basic-addon2">HH:mm</span>
                 </div>
 
@@ -129,9 +129,9 @@ class App extends Component {
                   <p>Skype <input name="setup[]" type="checkbox" value="Skype" onChange={this.handleChange}/></p>
                 </fieldset>
 
-                Other: <input className='form-control' name='setup' id='setup' type='text'/>
+                Other: <input pattern=".{0}|.{1,30}" title="Keep it to minimum of 30 characters" className='form-control' name='setup' id='setup' type='text'/>
                 <label htmlFor='interests'>Interests:</label>
-                <input className='form-control' name='interests' id='interests' type='text' value={this.state.interests} onChange={this.handleChange}/>
+                <input pattern=".{0}|.{1,30}" title="Keep it to minimum of 30 characters" className='form-control' name='interests' id='interests' type='text' value={this.state.interests} onChange={this.handleChange}/>
                 <input className='btn btn-success modal-submit' type='submit' value='Submit' />
               </form>
             </Modal.Body>


### PR DESCRIPTION
Added basic html 5 validations for the 4 input fields - username, time, interest, other.

**Limits the username to 20 characters and is a required field**

<img width="597" alt="screen shot 2016-12-07 at 19 21 31" src="https://cloud.githubusercontent.com/assets/16211277/20973579/20a1b704-bcbf-11e6-9de1-34915dc05984.png">





**Included error message for time field if the input from the user does not match the pattern**




<img width="551" alt="screen shot 2016-12-07 at 19 21 48" src="https://cloud.githubusercontent.com/assets/16211277/20973594/2f64698a-bcbf-11e6-94d7-10732b0d8533.png">





**Limits the 'Interest' and 'Other' fields to 30 characters in length. Also these to fields are not mandatory. The user can submit the form even if they don't fill out these forms **




<img width="627" alt="screen shot 2016-12-07 at 19 22 34" src="https://cloud.githubusercontent.com/assets/16211277/20973597/366e3ca6-bcbf-11e6-9adf-84f1c9c69e25.png">




Now the **text doesn't go out of screen area** as the characters are limited. Hope this helps