### PR TITLE
Fix not showing Pairing Technologies

### DIFF
--- a/src/components/ModalForm.js
+++ b/src/components/ModalForm.js
@@ -9,7 +9,7 @@ const ModalForm = props => {
     <form onSubmit={props.handleSubmit}>
         <AddModalUsernameInput username={props.username} handleChange={props.handleChange} />
         <AddModalAvailableTimeInput availableTime={props.availableTime} handleChange={props.handleChange} />
-        <ModalSelectionList modalSelections={props.modalSelections}/>
+        <ModalSelectionList modalSelections={props.modalSelections} handleChange={props.handleChange}/>
         <AddModalTextInput name="setup" label="Other" value="" handleChange={props.handleChange} />
         <AddModalTextInput name="interests" label="Interests" value={props.interests} handleChange={props.handleChange} />
         <input className='btn btn-success modal-submit' type='submit' value='Submit' />

--- a/src/components/ModalSelection.js
+++ b/src/components/ModalSelection.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ModalSelection = props => {
   return (
-    <p>{props.title} <input name="setup[]" type="checkbox" value="{props.title}" onChange={props.handleChange}/></p>
+    <p>{props.title} <input name="setup[]" type="checkbox" value={props.title} onChange={props.handleChange}/></p>
     );
 };
 


### PR DESCRIPTION
This partly fixes #87 

Now selecting pairing technologies work. Still inputting anything inside the "Other" field will overwrite this. Though by clicking another pairing option will again overwrite this. So as long as you clicked a pairing option after you entered something in "Other", you should be fine.