### PR TITLE
Fix "Other" input

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ class App extends Component {
       username: '',
       availableTime: '',
       setup: [],
+      otherSetup: '',
       interests: ''
     };
 
@@ -29,6 +30,7 @@ class App extends Component {
         username: '',
         availableTime: '',
         setup: [],
+        otherSetup: '',
         interests: ''
       });
     };
@@ -112,6 +114,7 @@ class App extends Component {
       username: this.state.username,
       availableTime: this.state.availableTime,
       setup: this.state.setup,
+      otherSetup: this.state.otherSetup,
       interests: this.state.interests
     }
     const url = `${server}/api/v1/posts`;

--- a/src/components/ModalForm.js
+++ b/src/components/ModalForm.js
@@ -9,7 +9,7 @@ const ModalForm = props => {
     <form onSubmit={props.handleSubmit}>
         <AddModalUsernameInput username={props.username} handleChange={props.handleChange} />
         <AddModalAvailableTimeInput availableTime={props.availableTime} handleChange={props.handleChange} />
-        <ModalSelectionList modalSelections={props.modalSelections}/>
+        <ModalSelectionList modalSelections={props.modalSelections} handleChange={props.handleChange}/>
         <AddModalTextInput name="setup" label="Other" value="" handleChange={props.handleChange} />
         <AddModalTextInput name="interests" label="Interests" value={props.interests} handleChange={props.handleChange} />
         <input className='btn btn-success modal-submit' type='submit' value='Submit' />

--- a/src/components/ModalForm.js
+++ b/src/components/ModalForm.js
@@ -10,7 +10,7 @@ const ModalForm = props => {
         <AddModalUsernameInput username={props.username} handleChange={props.handleChange} />
         <AddModalAvailableTimeInput availableTime={props.availableTime} handleChange={props.handleChange} />
         <ModalSelectionList modalSelections={props.modalSelections} handleChange={props.handleChange}/>
-        <AddModalTextInput name="setup" label="Other" value="" handleChange={props.handleChange} />
+        <AddModalTextInput name="otherSetup" label="Other" value={props.otherSetup} handleChange={props.handleChange} />
         <AddModalTextInput name="interests" label="Interests" value={props.interests} handleChange={props.handleChange} />
         <input className='btn btn-success modal-submit' type='submit' value='Submit' />
       </form>

--- a/src/components/ModalSelection.js
+++ b/src/components/ModalSelection.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const ModalSelection = props => {
   return (
-    <p>{props.title} <input name="setup[]" type="checkbox" value="{props.title}" onChange={props.handleChange}/></p>
+    <p>{props.title} <input name="setup[]" type="checkbox" value={props.title} onChange={props.handleChange}/></p>
     );
 };
 


### PR DESCRIPTION
This will change the name (and therefore ID) of the "Other" input field to `otherSetup`. It will also add `otherSetup` to the state as well as send it with the POST request. 

It is up to the backend to do something with it. As long as it doesn't do something, the input will just be ignored without giving an error. 

This is to fix #87  